### PR TITLE
Fixes Invalid values for nativeEnum #4

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -154,12 +154,15 @@ function extractFromZodSchema<ZSchema extends ZodTypeAny>(
 				}),
 			),
 		ZodNativeEnum: () =>
-			request(
-				'enum',
-				(): Record<string, unknown> => ({
-					possibleValues: Object.keys(schema._def.values ?? {}),
-				}),
-			),
+			request('enum', (): Record<string, unknown> => {
+				/** See https://blog.oyam.dev/typescript-enum-values/ */
+				const enumObject = schema._def.values;
+				return {
+					possibleValues: Object.keys(enumObject ?? {})
+						.filter(key => Number.isNaN(Number(key)))
+						.map(key => enumObject[key]),
+				};
+			}),
 		ZodUnion: () =>
 			request('union', (context): Record<string, unknown> => {
 				return {

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -409,7 +409,7 @@ describe('create enums', () => {
 			Banana,
 		}
 
-		expect(createFixture(z.nativeEnum(Fruits))).toMatch(/^0|1|Apple|Banana$/);
+		expect(createFixture(z.nativeEnum(Fruits))).toMatch(/^0|1/);
 	});
 
 	test('using string native enums creates an enum and returns a random value', () => {
@@ -419,9 +419,7 @@ describe('create enums', () => {
 			Cantaloupe = 3, // you can mix numerical and string enums
 		}
 
-		expect(createFixture(z.nativeEnum(Fruits))).toMatch(
-			/^apple|banana|Apple|Banana|Cantaloupe|3$/,
-		);
+		expect(createFixture(z.nativeEnum(Fruits))).toMatch(/^apple|banana|3$/);
 	});
 
 	test('using const native enums creates an enum and returns a random value', () => {
@@ -431,9 +429,7 @@ describe('create enums', () => {
 			Cantaloupe: 3,
 		} as const;
 
-		expect(createFixture(z.nativeEnum(Fruits))).toMatch(
-			/^apple|banana|Apple|Banana|Cantaloupe|3$/,
-		);
+		expect(createFixture(z.nativeEnum(Fruits))).toMatch(/^apple|banana|3$/);
 	});
 });
 


### PR DESCRIPTION
This PR fixes #4.

It's not as simple as just getting `Object.values(enum)`, given the output for numeric enums contains the keys as well.

[Other libraries](https://github.com/anatine/zod-plugins/blob/main/packages/zod-mock/src/lib/zod-mock.ts#L337-L342) dealing with this [also struggle](https://github.com/anatine/zod-plugins/issues/48) with the topic.

The function shared [in this post](https://blog.oyam.dev/typescript-enum-values/) makes sense and works well.