### PR TITLE
Fixed issue with object schema & transform

### DIFF
--- a/src/create-fixture.ts
+++ b/src/create-fixture.ts
@@ -21,6 +21,7 @@ import {
 	unionRandomizeCustomization,
 } from './customizations';
 import type { Customization } from './customizations';
+import { effectCustomization } from './customizations/effect-customization';
 import { generate } from './generate';
 import { tupleCustomization } from './customizations/tuple-customization';
 
@@ -47,6 +48,7 @@ const defaultCustomizations = [
 	setCustomization() as Customization<Record<string, unknown>>,
 	tupleCustomization() as Customization<Record<string, unknown>>,
 	unionRandomizeCustomization() as Customization<Record<string, unknown>>,
+	effectCustomization() as Customization<Record<string, unknown>>,
 ];
 
 export function createFixture<ZSchema extends ZodTypeAny>(

--- a/src/customizations/effect-customization.ts
+++ b/src/customizations/effect-customization.ts
@@ -1,0 +1,34 @@
+import type { Customization } from './customization';
+import type { Effect } from 'zod';
+
+type EffectContext<T> = {
+	effect: Effect<T>;
+	inner: {
+		path: string[];
+		type: string;
+		create: () => T;
+	};
+};
+
+export const effectCustomization = (): Customization<
+	EffectContext<unknown>
+> => {
+	return {
+		condition: ({ type }) => type === 'effect',
+		generator,
+	};
+};
+
+function generator<T>({ effect, inner }: EffectContext<T>): T {
+	if (effect.type === 'transform') {
+		const output = effect.transform(inner.create(), {
+			addIssue: () => {
+				/* noop */
+			},
+			path: inner.path,
+		});
+		return output;
+	}
+
+	return inner.create();
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -214,11 +214,19 @@ function extractFromZodSchema<ZSchema extends ZodTypeAny>(
 		ZodAny: () => request('any'),
 		ZodUnknown: () => request('unknown'),
 		ZodNever: () => request('never'),
-		ZodEffects: () => {
-			const { type, createValue } = extractFromZodSchema(schema._def.schema);
+		ZodEffects: () =>
+			request('effect', (context): Record<string, unknown> => {
+				const innerType = extractFromZodSchema(schema._def.schema).type;
 
-			return [type, createValue];
-		},
+				return {
+					effect: schema._def.effect,
+					inner: {
+						path: context.path,
+						type: innerType,
+						create: () => generate(schema._def.schema, context),
+					},
+				};
+			}),
 	};
 
 	const zodToRequest = mapper[schema._def.typeName];

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -214,7 +214,11 @@ function extractFromZodSchema<ZSchema extends ZodTypeAny>(
 		ZodAny: () => request('any'),
 		ZodUnknown: () => request('unknown'),
 		ZodNever: () => request('never'),
-		ZodEffects: () => request(extractFromZodSchema(schema._def.schema).type),
+		ZodEffects: () => {
+			const { type, createValue } = extractFromZodSchema(schema._def.schema);
+
+			return [type, createValue];
+		},
 	};
 
 	const zodToRequest = mapper[schema._def.typeName];
@@ -233,7 +237,7 @@ function extractConditions<ZSchema extends ZodTypeAny>(
 	schema: ZSchema,
 ): Condition {
 	const checks = [...(schema._def.checks || [])];
-	
+
 	if (schema._def.minLength) {
 		checks.push({ kind: 'min', value: schema._def.minLength.value });
 	}

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -59,7 +59,9 @@ describe('create strings', () => {
 	});
 
 	test('creates a string that is a uuid', () => {
-		expect(createFixture(z.string().uuid())).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+		expect(createFixture(z.string().uuid())).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+		);
 	});
 });
 
@@ -287,6 +289,18 @@ describe('create objects', () => {
 		});
 		expect(() => {
 			createFixture(SampleWithOptionalValueSchema);
+		}).not.toThrow();
+	});
+
+	test('creates object with transform', () => {
+		const schema = z
+			.object({
+				v: z.string(),
+			})
+			.transform(v => v);
+
+		expect(() => {
+			createFixture(schema);
 		}).not.toThrow();
 	});
 });


### PR DESCRIPTION
Hello @timdeschryver :wave:,

Thank you for this fantastic library. It simplifies testing a lot 🙏

While using it, I've encountered a minor issue: when some object schema uses [`transform`](https://zod.dev/?id=transform), this library throws an error: "Cannot convert null or undefined to object". There was a minor issue - [ZodEffects](https://github.com/ArtiomTr/zod-fixture/blob/216ee83441909fed56bc76ee3f8dda65ff1fb3cc/src/generate.ts#L217) mapper was returning only a type, without `createValue` function. Without this function, the object customizer could not find the object schema and crash.

I've fixed this issue and added an appropriate test case. Let me know if some modifications are necessary.

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/ArtiomTr/zod-fixture/tree/main"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/ArtiomTr/zod-fixture/tree/main)._