### PR TITLE
Excluded cuid and @paralleldrive/cuid2 from bundle

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,5 +14,8 @@ export default defineConfig({
 			formats: ['es', 'umd'],
 			fileName: format => `zod-fixture.${format}.js`,
 		},
+		rollupOptions: {
+			external: ['cuid', '@paralleldrive/cuid2'],
+		},
 	},
 });


### PR DESCRIPTION
This PR closes #7 

In this PR, dependencies `cuid` and `@paralleldrive/cuid2` are excluded from the bundle. This will possibly allow us to use this library in different environments - browser, react-native and nodejs.