### PR TITLE
Adds cjs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
 	"files": [
 		"dist"
 	],
-	"main": "./dist/zod-fixture.umd.js",
+	"main": "./dist/zod-fixture.umd.cjs",
 	"module": "./dist/zod-fixture.es.js",
 	"exports": {
 		".": {
 			"import": "./dist/zod-fixture.es.js",
-			"require": "./dist/zod-fixture.umd.js"
+			"require": "./dist/zod-fixture.umd.cjs"
 		}
 	},
 	"types": "./dist/index.d.ts",

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
 			entry: './src/index.ts',
 			name: 'zod-fixture',
 			formats: ['es', 'umd'],
-			fileName: format => `zod-fixture.${format}.js`,
+			fileName: format => `zod-fixture.${format}.${format === 'umd' ? 'cjs' : 'js'}`,
 		},
 		rollupOptions: {
 			external: ['cuid', '@paralleldrive/cuid2'],


### PR DESCRIPTION
Was worried about changing the build output from UMD to CJS, turns out all it needed was a file extension change though. 

Tested locally, previous error:
![image](https://github.com/timdeschryver/zod-fixture/assets/24485514/d628568d-1d37-4852-9075-fdd291e4822b)

Everything runs fine once umd file name was changed from `.umd.js` -> `.umd.cjs`. 