### PR TITLE
test: generator order

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -22,8 +22,8 @@ export class Core {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	register(generators: Definition<any>[]) {
-		this.#generators = generators.concat(this.#generators);
+	register(generators: Definition<any> | Definition<any>[]): this {
+		this.#generators = this.#generators.concat(generators);
 		return this;
 	}
 

--- a/src/fixture.test.ts
+++ b/src/fixture.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import { ZodNumber, z } from 'zod';
+import { Generator } from './core/generator';
+import { createFixture } from './fixture';
+
+test('creates a fixture', () => {
+	const PersonSchema = z.object({
+		name: z.string(),
+		birthday: z.date(),
+		address: z.object({
+			street: z.string(),
+			city: z.string(),
+			state: z.string(),
+		}),
+		pets: z.array(z.object({ name: z.string(), breed: z.string() })),
+		totalVisits: z.number(),
+	});
+
+	const result = createFixture(PersonSchema);
+	expect(result.name).toBeTypeOf('string');
+	expect(result.birthday).toBeInstanceOf(Date);
+	expect(result.address).toBeTypeOf('object');
+	expect(result.address.street).toBeTypeOf('string');
+	expect(result.address.city).toBeTypeOf('string');
+	expect(result.address.state).toBeTypeOf('string');
+	expect(result.pets).toBeInstanceOf(Array);
+	expect(result.pets[0]).toBeTypeOf('object');
+	expect(result.pets[0]?.name).toBeTypeOf('string');
+	expect(result.pets[0]?.breed).toBeTypeOf('string');
+	expect(result.totalVisits).toBeTypeOf('number');
+});
+
+test(`priotizes generators via extend`, () => {
+	const FooNumberGenerator = Generator({
+		schema: ZodNumber,
+		matches: (x) => x.context?.path?.includes('foo'),
+		output: () => {
+			return 4;
+		},
+	});
+
+	const result = createFixture(
+		z.object({
+			foo: z.number(),
+			other: z.number(),
+		}),
+		{
+			extend: [FooNumberGenerator],
+		}
+	);
+
+	expect(result.foo).toBe(4);
+	expect(result.other).toBeTypeOf('number');
+});

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -1,0 +1,18 @@
+import type { ZodTypeAny, z } from 'zod';
+import type { Config } from './core/core';
+import { Core } from './core/core';
+import type { Definition } from './core/generator';
+import defaultGenerators from './generators/default';
+
+export function createFixture<TSchema extends ZodTypeAny>(
+	schema: TSchema,
+	config: Config & {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		extend?: Definition<any>[];
+	} = {}
+): z.infer<TSchema> {
+	return new Core(config)
+		.register(config.extend ?? [])
+		.register(defaultGenerators)
+		.generate(schema);
+}

--- a/src/fixture.ts
+++ b/src/fixture.ts
@@ -8,7 +8,7 @@ export function createFixture<TSchema extends ZodTypeAny>(
 	schema: TSchema,
 	config: Config & {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		extend?: Definition<any>[];
+		extend?: Definition<any> | Definition<any>[];
 	} = {}
 ): z.infer<TSchema> {
 	return new Core(config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,3 @@
-import type { Definition } from '@/core/generator';
-import type { ZodTypeAny, z } from 'zod';
-import type { Config } from './core/core';
-import { Core } from './core/core';
-import defaultGenerators from './generators/default';
-
 export { Core } from '@/core/core';
 export { Generator } from '@/core/generator';
-
-export function createFixture<TSchema extends ZodTypeAny>(
-	schema: TSchema,
-	config: Config & {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		extend?: Definition<any>[];
-	} = {}
-): z.infer<TSchema> {
-	return new Core(config)
-		.register(defaultGenerators)
-		.register(config.extend ?? [])
-		.generate(schema);
-}
+export { createFixture } from '@/fixture';

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { z } from 'zod';
-import { Core } from '../src';
+import { ZodNumber, z } from 'zod';
+import { Core, Generator } from '../src';
 import defaultGenerators from '../src/generators/default';
+import { NumberGenerator } from '../src/generators/default/number';
+import { ObjectGenerator } from '../src/generators/default/object';
 import { StringGenerator } from '../src/generators/default/string';
 
 describe('core', () => {
@@ -48,5 +50,49 @@ describe('core', () => {
 		expect(() => core.generate(PersonSchema)).toThrow(
 			/No generator found for ZodString/i
 		);
+	});
+
+	describe('order of generators', () => {
+		const FooNumberGenerator = Generator({
+			schema: ZodNumber,
+			matches: (x) => x.context?.path?.includes('foo'),
+			output: () => {
+				return 4;
+			},
+		});
+
+		test(`test one`, () => {
+			const core = new Core().register([
+				ObjectGenerator,
+				FooNumberGenerator,
+				NumberGenerator,
+			]);
+
+			const result = core.generate(
+				z.object({
+					foo: z.number(),
+					other: z.number(),
+				})
+			);
+
+			expect(result.foo).toBe(4);
+		});
+
+		test.fails(`test two`, () => {
+			const core = new Core().register([
+				ObjectGenerator,
+				NumberGenerator,
+				FooNumberGenerator,
+			]);
+
+			const result = core.generate(
+				z.object({
+					foo: z.number(),
+					other: z.number(),
+				})
+			);
+
+			expect(result.foo).toBe(4);
+		});
 	});
 });


### PR DESCRIPTION
I think ideally both tests should succeed.

Maybe look into giving the custom generators priority over the default ones? 