### PR TITLE
createFixture Tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,5 @@ export function createFixture<TSchema extends ZodTypeAny>(
 		.register(config.extend ?? [])
 		.generate(schema);
 }
+
+export default createFixture;

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { z } from 'zod';
-import { Core } from '../src';
+import { ZodNumber, z } from 'zod';
+import { Core, Generator } from '../src';
 import defaultGenerators from '../src/generators/default';
+import { NumberGenerator } from '../src/generators/default/number';
+import { ObjectGenerator } from '../src/generators/default/object';
 import { StringGenerator } from '../src/generators/default/string';
 
 describe('core', () => {
@@ -48,5 +50,49 @@ describe('core', () => {
 		expect(() => core.generate(PersonSchema)).toThrow(
 			/No generator found for ZodString/i
 		);
+	});
+
+	describe('order of generators', () => {
+		const FooNumberGenerator = Generator({
+			schema: ZodNumber,
+			matches: (x) => x.context?.path?.includes('foo'),
+			output: () => {
+				return 4;
+			},
+		});
+
+		test(`test one`, () => {
+			const core = new Core().register([
+				ObjectGenerator,
+				FooNumberGenerator,
+				NumberGenerator,
+			]);
+
+			const result = core.generate(
+				z.object({
+					foo: z.number(),
+					other: z.number(),
+				})
+			);
+
+			expect(result.foo).toBe(4);
+		});
+
+		test.fails(`test two`, () => {
+			const core = new Core().register([
+				ObjectGenerator,
+				NumberGenerator,
+				FooNumberGenerator,
+			]);
+
+			const result = core.generate(
+				z.object({
+					foo: z.number(),
+					other: z.number(),
+				})
+			);
+
+			expect(result.foo).toBe(4);
+		});
 	});
 });


### PR DESCRIPTION
This further refines the distinction between `core` and `createFixture` by separating tests and making `createFixture` the default export for the entire library.

`core` should be thought of as an un-opinionated utility for traversing a Zod schema with no deterministic way of deducing the resulting output type (because filters are calculated at runtime).

`createFixture`, on the other hand, has the very distinct purpose of generating a fixture that matches the type provided by Zod and passes all Zod validations.

I know it's not entirely transparent why I'm doing this at the moment, but I'd like to retain the flexibility of `core` to produce things that are not true fixtures so that I can re-use it to create a serialized schema and a dynamic, configurable fixture generator. This would allow a 3rd party extension or library to "read" the schema, provide the user with the ability to select branches of the schema, and then modify the configurable generators to produce a fixture that matches that selection. I believe a tool like this can be used in combination with MSW during development to create a deterministic response so that various states can be properly defined in the UI.