### PR TITLE
Schema Validation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,6 @@ module.exports = {
 			'error',
 			{ prefer: 'type-imports' },
 		],
+		'@typescript-eslint/no-empty-interface': 'off',
 	},
 };

--- a/.vitest/extend.ts
+++ b/.vitest/extend.ts
@@ -1,0 +1,17 @@
+import { expect } from 'vitest';
+
+expect.extend({
+	toBeZodType(actual, { schema, core }) {
+		const { success: pass, error } = schema.safeParse(actual);
+
+		return {
+			pass,
+			message: () =>
+				JSON.stringify({
+					fixture: actual,
+					seed: core.seed,
+					error,
+				}, null, 2),
+		};
+	},
+});

--- a/.vitest/extend.ts
+++ b/.vitest/extend.ts
@@ -1,17 +1,32 @@
 import { expect } from 'vitest';
 
+const ITERATIONS = 100;
+
 expect.extend({
-	toBeZodType(actual, { schema, core }) {
-		const { success: pass, error } = schema.safeParse(actual);
+	toProduce(core, schema) {
+		for (let i = 0; i < ITERATIONS; i++) {
+			const fixture = core.generate(schema);
+			const { success: pass, error } = schema.safeParse(fixture);
+
+			if (!pass)
+				return {
+					pass,
+					message: () =>
+						JSON.stringify(
+							{
+								fixture,
+								seed: core.seed,
+								error,
+							},
+							null,
+							2
+						),
+				};
+		}
 
 		return {
-			pass,
-			message: () =>
-				JSON.stringify({
-					fixture: actual,
-					seed: core.seed,
-					error,
-				}, null, 2),
+			pass: true,
+			message: () => `Successfully ran ${ITERATIONS} iterations.`,
 		};
 	},
 });

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -57,10 +57,8 @@ describe('core', () => {
 		test(`picks up the first matching generator`, () => {
 			const FooNumberGenerator = Generator({
 				schema: ZodNumber,
-				matches: (x) => x.context?.path?.includes('foo'),
-				output: () => {
-					return 4;
-				},
+				filter: ({ context }) => context?.path?.includes('foo'),
+				output: () => 4,
 			});
 
 			const core = new Core().register([
@@ -83,10 +81,8 @@ describe('core', () => {
 		test(`picks up the first matching generator using register`, () => {
 			const FooNumberGenerator = Generator({
 				schema: ZodNumber,
-				matches: (x) => x.context?.path?.includes('foo'),
-				output: () => {
-					return 4;
-				},
+				filter: ({ context }) => context?.path?.includes('foo'),
+				output: () => 4,
 			});
 
 			const core = new Core().register([ObjectGenerator]);

--- a/src/fixture.test.ts
+++ b/src/fixture.test.ts
@@ -33,10 +33,8 @@ test('creates a fixture', () => {
 test(`priotizes generators via extend`, () => {
 	const FooNumberGenerator = Generator({
 		schema: ZodNumber,
-		matches: (x) => x.context?.path?.includes('foo'),
-		output: () => {
-			return 4;
-		},
+		filter: ({ context }) => context?.path?.includes('foo'),
+		output: () => 4,
 	});
 
 	const result = createFixture(

--- a/src/generators/default/number/number.test.ts
+++ b/src/generators/default/number/number.test.ts
@@ -58,7 +58,6 @@ describe('create numbers', () => {
 
 	test("creates a number that's a multiple", () => {
 		const schema = z.number().multipleOf(4);
-		const result = core.generate(schema);
-		expect(result).toBeZodType({ schema, core });
+		expect(core).toProduce(schema);
 	});
 });

--- a/src/generators/default/number/number.test.ts
+++ b/src/generators/default/number/number.test.ts
@@ -55,4 +55,10 @@ describe('create numbers', () => {
 	test('throws when min is greater than max', () => {
 		expect(() => core.generate(z.number().min(100).max(10))).toThrowError();
 	});
+
+	test("creates a number that's a multiple", () => {
+		const schema = z.number().multipleOf(4);
+		const result = core.generate(schema);
+		expect(result).toBeZodType({ schema, core });
+	});
 });

--- a/src/types/vite-env.d.ts
+++ b/src/types/vite-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite/client" />

--- a/src/types/vitest.d.ts
+++ b/src/types/vitest.d.ts
@@ -1,0 +1,12 @@
+import type { ZodTypeAny } from 'zod';
+import type { Core } from '../src/core/core';
+
+interface CustomMatchers<R = unknown> {
+	toBeZodType(params: { schema: ZodTypeAny; core: Core }): R;
+}
+
+declare module 'vitest' {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	interface Assertion<T = any> extends CustomMatchers<T> {}
+	interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/src/types/vitest.d.ts
+++ b/src/types/vitest.d.ts
@@ -1,8 +1,7 @@
 import type { ZodTypeAny } from 'zod';
-import type { Core } from '../src/core/core';
 
 interface CustomMatchers<R = unknown> {
-	toBeZodType(params: { schema: ZodTypeAny; core: Core }): R;
+	toProduce(schema: ZodTypeAny): R;
 }
 
 declare module 'vitest' {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,11 @@
 		"declaration": true,
 		"importHelpers": true,
 		"inlineSourceMap": true,
+		"typeRoots": ["./src/types", "./node_modules", "./node_modules/@types/"],
+		"noEmit": true,
+		"isolatedModules": true, // https://vitejs.dev/guide/features.html#isolatedmodules
+		"useDefineForClassFields": true, // https://vitejs.dev/guide/features.html#usedefineforclassfields
+		"types": ["vite/client"], // https://vitejs.dev/guide/features.html#client-types
 		"baseUrl": "./src",
 		"paths": {
 			"@/*": ["*"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,8 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite';
-import dts from 'vite-plugin-dts';
 import path from 'path';
+import dts from 'vite-plugin-dts';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	test: ['./src/*'],
 	resolve: {
 		alias: {
 			// eslint-disable-next-line no-undef
@@ -33,5 +31,8 @@ export default defineConfig({
 		esbuildOptions: {
 			target: 'esnext',
 		},
+	},
+	test: {
+		setupFiles: ['./.vitest/extend.ts'],
 	},
 });


### PR DESCRIPTION
Extends vitest asserts to include a helper that will attempt to parse a fixture against the schema that produced it. Why did I do this? This type of test isn't deterministic in nature since most fixtures generate random values. If a test fails, we would not have enough information to reproduce it. This helper ensures that we have a copy of the seed that produced the fixture so that, in the event that we do get an error, we can accurately reproduce it using the seed provided as input to MersenneTwister.

Case in point. This PR is failing because the multipleOf test failed. Notice that the seed is present so we can accurately reproduce this specific failure and retest.

<img width="787" alt="Screenshot 2023-06-24 at 6 04 16 PM" src="https://github.com/timdeschryver/zod-fixture/assets/880190/cbcbaf45-1c1e-4dae-9b5c-61c9c9599452">

