### PR TITLE
toProduce accepts `undefined`

### DIFF
--- a/.vitest/extend.ts
+++ b/.vitest/extend.ts
@@ -23,7 +23,7 @@ expect.extend({
 						),
 				};
 
-			if (result !== undefined) {
+			if (arguments.length === 3) {
 				expect(fixture).toBe(result);
 			}
 		}


### PR DESCRIPTION
The original implementation checked for the existence of `undefined` on the expected result. This creates an edge case where `undefined` can not be the expected result. By looking at the arguments length, we can establish if a 3rd parameter was passed, regardless of its value. 