### PR TITLE
support for zod's string-specific .url() validation

### DIFF
--- a/src/customizations/string-customization.ts
+++ b/src/customizations/string-customization.ts
@@ -45,6 +45,9 @@ export const stringCustomization = (): Customization => {
 				return generateDateTimeString();
 			}
 
+			if (checks['url']) {
+				return `https://${generateString(propertName)}.com`
+			}
 			return generateString(propertName);
 		},
 	};

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -291,6 +291,7 @@ function extractConditions<ZSchema extends ZodTypeAny>(
 				case 'cuid2':
 				case 'datetime':
 				case 'email':
+				case 'url':
 					return {
 						...aggregate,
 						[check.kind]: true,

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -117,6 +117,13 @@ describe('create strings', () => {
 		const isoDateTimeString = createFixture(schema);
 		schema.parse(isoDateTimeString);
 	});
+
+	test('creates a string that is an url', () => {
+		const schema = z.string().url();
+
+		const url = createFixture(schema);
+		schema.parse(url)
+	});
 });
 
 describe('create numbers', () => {


### PR DESCRIPTION
Added support for schemas like

`z.string().url()`

Generated fixtures examples: 
  * `sourceUrl: z.string().url()` -> `"https://sourceUrl-df7b5156-0a7d-43d3-9c6e-428399c58c5f.com"`
  * `url: z.string().url()` -> `"https://url-0b54cdb7-b10b-4e97-9d3c-bc81a3d8cc73.com"`
