### PR TITLE
docs: fix install & add z.instanceof

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,15 @@ For example, in the example below we create our own `totalVisitsGenerator` to re
 <<< @/../examples/custom-type.test.ts#output [Output]
 :::
 
+### `z.instanceof` isn't returning what I expected. What gives?
+
+`z.instanceof` is one of the few schemas that doesn't have first party support in `zod`. It's technically a `z.custom` under the hood, which means the only way to match is for you to create a custom generator and pass an instance of it as your schema.
+
+::: code-group
+<<< @/../examples/instanceof-type.test.ts#example [Example]
+<<< @/../examples/instanceof-type.test.ts#output [Output]
+:::
+
 ### Do you support faker/chance/falso?
 
 The short answer, not yet. We plan to build out pre-defined generators for popular mocking libraries but are currently prioritizing reliability and ease of use. If you'd like to help us build out this functionality, feel free to open a pull request 😀

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,15 +22,15 @@ Creating test fixtures should be easy.<br>
 ::: code-group
 
 ```sh [npm]
-npm install -D vitepress
+npm install -D zod-fixture
 ```
 
 ```sh [pnpm]
-pnpm add -D vitepress
+pnpm add -D zod-fixture
 ```
 
 ```sh [yarn]
-yarn add -D vitepress
+yarn add -D zod-fixture
 ```
 
 ```sh [bun]

--- a/examples/custom-type.test.ts
+++ b/examples/custom-type.test.ts
@@ -33,6 +33,12 @@ const output = Object.assign(
 	// #endregion output
 );
 
-test('generates a person', () => {
+test('generates a resolution', () => {
+	expect(resolution).toMatchInlineSnapshot(`
+		{
+		  "height": "100px",
+		  "width": "100px",
+		}
+	`);
 	expect(resolution).toEqual(output);
 });

--- a/examples/instanceof-type.test.ts
+++ b/examples/instanceof-type.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest';
+// #region example
+import { z } from 'zod';
+import { Fixture, Generator } from 'zod-fixture';
+
+class ExampleClass {
+	id: number;
+	constructor() {
+		this.id = ExampleClass.uuid++;
+	}
+	static uuid = 1;
+}
+
+// Schema from instanceof (remember, this is just a z.custom)
+const exampleSchema = z.instanceof(ExampleClass);
+
+// Your custom generator
+const ExampleGenerator = Generator({
+	schema: exampleSchema,
+	output: () => new ExampleClass(),
+});
+
+// Example
+const listSchema = z.object({
+	examples: exampleSchema.array(),
+});
+
+const fixture = new Fixture().extend(ExampleGenerator);
+const result = fixture.fromSchema(listSchema);
+// #endregion example
+
+const output = Object.assign(
+	// #region output
+	{
+		examples: [
+			{
+				id: 1,
+			},
+			{
+				id: 2,
+			},
+			{
+				id: 3,
+			},
+		],
+	}
+	// #endregion output
+);
+
+test('generates an instance of acme', () => {
+	expect(result).toMatchInlineSnapshot(`
+		{
+		  "examples": [
+		    ExampleClass {
+		      "id": 1,
+		    },
+		    ExampleClass {
+		      "id": 2,
+		    },
+		    ExampleClass {
+		      "id": 3,
+		    },
+		  ],
+		}
+	`);
+	expect(result).toEqual(output);
+});


### PR DESCRIPTION
Addresses the installation mismatch: https://github.com/timdeschryver/zod-fixture/issues/68

Also adds documentation for the use of `z.instanceof` (we can't directly support it).