### PR TITLE
fix: defaults conflict with user checks

### DIFF
--- a/src/fixture/generators/array/array.test.ts
+++ b/src/fixture/generators/array/array.test.ts
@@ -26,4 +26,10 @@ describe('create Arrays', () => {
 			transform.fromSchema(z.array(z.string()).min(10).max(5))
 		).toThrowError();
 	});
+
+	test('should honor the constraints of the schema', () => {
+		const schema = z.string().array().min(5);
+		const fixture = transform.fromSchema(schema);
+		expect(() => schema.parse(fixture)).not.toThrowError();
+	});
 });

--- a/src/fixture/generators/array/index.ts
+++ b/src/fixture/generators/array/index.ts
@@ -4,14 +4,22 @@ import { Generator } from '@/transformer/generator';
 export const ArrayGenerator = Generator({
 	schema: ZodArray,
 	output: ({ def, transform, context }) => {
-		const min =
-			def.minLength?.value ??
-			def.exactLength?.value ??
-			transform.defaults.array.min;
-		const max =
-			def.maxLength?.value ??
-			def.exactLength?.value ??
-			transform.defaults.array.max;
+		const userDefinedMin = def.minLength?.value ?? def.exactLength?.value;
+		const userDefinedMax = def.maxLength?.value ?? def.exactLength?.value;
+
+		const min = transform.utils.resolveValue({
+			initial: userDefinedMin,
+			fallback: transform.defaults.array.min,
+			conflict: userDefinedMax,
+			resolve: (options) => Math.min(options.fallback, options.conflict),
+		});
+
+		const max = transform.utils.resolveValue({
+			initial: userDefinedMax,
+			fallback: transform.defaults.array.max,
+			conflict: userDefinedMin,
+			resolve: (options) => Math.max(options.fallback, options.conflict),
+		});
 
 		const result: unknown[] = [];
 

--- a/src/fixture/generators/set/index.ts
+++ b/src/fixture/generators/set/index.ts
@@ -5,8 +5,22 @@ import type { z } from 'zod';
 export const SetGenerator = Generator({
 	schema: ZodSet,
 	output: ({ def, transform, context }) => {
-		const min = def.minSize?.value ?? transform.defaults.set.min;
-		const max = def.maxSize?.value ?? transform.defaults.set.max;
+		const userDefinedMin = def.minSize?.value;
+		const userDefinedMax = def.maxSize?.value;
+
+		const min = transform.utils.resolveValue({
+			initial: userDefinedMin,
+			fallback: transform.defaults.set.min,
+			conflict: userDefinedMax,
+			resolve: (options) => Math.min(options.fallback, options.conflict),
+		});
+
+		const max = transform.utils.resolveValue({
+			initial: userDefinedMax,
+			fallback: transform.defaults.set.max,
+			conflict: userDefinedMin,
+			resolve: (options) => Math.max(options.fallback, options.conflict),
+		});
 
 		const result = new Set<z.infer<typeof def.valueType>>();
 

--- a/src/fixture/generators/set/set.test.ts
+++ b/src/fixture/generators/set/set.test.ts
@@ -24,4 +24,10 @@ describe('create Sets', () => {
 		expect([...(result as I).keys()][0]).toBeTypeOf('number');
 		expect([...(result as I).values()][0]).toBeTypeOf('number');
 	});
+
+	test('should honor the constraints of the schema', () => {
+		const schema = z.set(z.number()).min(5);
+		const fixture = transform.fromSchema(schema);
+		expect(() => schema.parse(fixture)).not.toThrowError();
+	});
 });

--- a/src/transformer/utils/index.ts
+++ b/src/transformer/utils/index.ts
@@ -10,6 +10,39 @@ export class Utils {
 		this.random = new Randomization(runner.defaults);
 	}
 
+	resolveValue<
+		TInitial,
+		TFallback extends NonNullable<TInitial>,
+		TConflict extends NonNullable<TInitial>
+	>(
+		config:
+			| {
+					initial: TInitial;
+					fallback: TFallback;
+			  }
+			| {
+					initial: TInitial;
+					fallback: TFallback;
+					conflict: TConflict;
+					resolve: (config: {
+						fallback: TFallback;
+						conflict: TConflict;
+					}) => NonNullable<TInitial>;
+			  }
+	): NonNullable<TInitial> {
+		const { initial, fallback } = config;
+
+		if (initial != null) return initial;
+
+		if ('conflict' in config) {
+			const { conflict, resolve } = config;
+
+			return conflict != null ? resolve({ fallback, conflict }) : fallback;
+		} else {
+			return fallback;
+		}
+	}
+
 	n<T>(
 		factory: (index: number) => T,
 		config: number | { min: number; max: number } = this.runner.defaults.array


### PR DESCRIPTION
This PR adds a new utility `resolveValue` that takes an initial value, a fallback value, and a potential conflicting value (from checks, etc). The return value matches the typeof the initial value and is determined using the following logic:
1. If the value is defined, return the value
2. If the value is undefined and there's a conflicting value that IS defined, use a resolver to calculate the return value
3. If the value is undefined and the conflicting value is undefined, use the "fallback" value (ie default value).