### PR TITLE
feat: Optional Generator Schema

### DIFF
--- a/src/transformer/generator.ts
+++ b/src/transformer/generator.ts
@@ -33,7 +33,7 @@ export function isZodConstructor(
 }
 
 // #region filter
-type Filter<TSchema extends ZodTypeAny> = (obj: {
+type Filter<TSchema extends ZodTypeAny = ZodTypeAny> = (obj: {
 	def: TSchema['_def'];
 	schema: TSchema;
 	transform: Runner;
@@ -41,25 +41,27 @@ type Filter<TSchema extends ZodTypeAny> = (obj: {
 }) => boolean;
 // #endregion filter
 
-export type Generator<TSchema extends ZodTypeAny> = (obj: {
+export type Generator<TSchema extends ZodTypeAny = ZodTypeAny> = (obj: {
 	def: TSchema['_def'];
 	schema: TSchema;
 	transform: Runner;
 	context: Context;
 }) => unknown;
 
-export interface Definition<TSchema extends ZodTypeAny> {
-	schema: ZodConstructorOrSchema<TSchema>;
+export interface Definition<TSchema extends ZodTypeAny = ZodTypeAny> {
+	schema?: ZodConstructorOrSchema<TSchema>;
 	filter?: Filter<TSchema>;
 	output: Generator<TSchema>;
 }
 
-export function Generator<TSchema extends ZodTypeAny>(
+export function Generator<TSchema extends ZodTypeAny = ZodTypeAny>(
 	definition: Definition<TSchema>
 ): Definition<TSchema> {
-	if (!isZodConstructor(definition.schema)) {
-		if (definition.schema[ZOD_INSTANCE_IDENTIFIER] === undefined)
-			definition.schema[ZOD_INSTANCE_IDENTIFIER] = Generator.uuid++;
+	if (definition.schema !== undefined) {
+		if (!isZodConstructor(definition.schema)) {
+			if (definition.schema[ZOD_INSTANCE_IDENTIFIER] === undefined)
+				definition.schema[ZOD_INSTANCE_IDENTIFIER] = Generator.uuid++;
+		}
 	}
 
 	return definition;

--- a/src/transformer/runner.ts
+++ b/src/transformer/runner.ts
@@ -1,7 +1,6 @@
 import type { ZodTypeAny } from 'zod';
 import type { Defaults } from './defaults';
 import type { Context } from './generator';
-import { ZOD_INSTANCE_IDENTIFIER, isZodConstructor } from './generator';
 import type { Transformer } from './transformer';
 import { Utils } from './utils';
 
@@ -29,23 +28,8 @@ export class Runner {
 		const transform = this;
 		const def = schema._def;
 		const generator = this.transformer.generators.find((generator) => {
-			const generaterType = isZodConstructor(generator.schema)
-				? generator.schema.name
-				: generator.schema._def.typeName;
-
-			if (def.typeName !== generaterType) {
+			if (!transform.utils.isType(generator.schema, schema)) {
 				return false;
-			}
-
-			// If our generator was created with an instance, make sure it matches
-			// the schema we're trying to generate.
-			// This is particularly important for z.custom schemas.
-			if (generator.schema[ZOD_INSTANCE_IDENTIFIER] !== undefined) {
-				if (
-					schema[ZOD_INSTANCE_IDENTIFIER] !==
-					generator.schema[ZOD_INSTANCE_IDENTIFIER]
-				)
-					return false;
 			}
 
 			if (

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -6,7 +6,7 @@ import { Runner } from './runner';
 
 export abstract class Transformer {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	abstract readonly generators: Definition<any>[];
+	abstract readonly generators: Definition[];
 	abstract readonly transformerDefaults: Defaults;
 
 	constructor(readonly instanceDefaults?: Partial<Defaults>) {
@@ -14,7 +14,7 @@ export abstract class Transformer {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	extend(generators: Definition<any> | Definition<any>[]) {
+	extend(generators: Definition | Definition[]) {
 		const input = Array.isArray(generators) ? generators : [generators];
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore     We're allowed to update this internally
@@ -36,12 +36,12 @@ export abstract class Transformer {
 
 export class ConstrainedTransformer extends Transformer {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	generators: Definition<any>[] = [];
+	generators: Definition[] = [];
 	transformerDefaults: Defaults = constrained;
 }
 
 export class UnconstrainedTransformer extends Transformer {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	generators: Definition<any>[] = [];
+	generators: Definition[] = [];
 	transformerDefaults: Defaults = unconstrained;
 }

--- a/src/transformer/utils/Checks.ts
+++ b/src/transformer/utils/Checks.ts
@@ -1,3 +1,5 @@
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
+
 export class Checks<TChecks extends { kind: string }[]> {
 	constructor(private checks: TChecks) {}
 
@@ -14,7 +16,8 @@ export class Checks<TChecks extends { kind: string }[]> {
 	}
 }
 
-type FilterChecks<
-	T extends { kind: string },
-	TKind extends string
-> = T extends { kind: TKind } ? T : never;
+type FilterChecks<T extends { kind: string }, TKind extends string> = IfAny<
+	T,
+	unknown,
+	T extends { kind: TKind } ? T : never
+>;

--- a/src/transformer/utils/index.ts
+++ b/src/transformer/utils/index.ts
@@ -1,4 +1,6 @@
 import type { ZodTypeAny } from 'zod';
+import type { ZodConstructorOrSchema } from '../generator';
+import { isZodConstructor, ZOD_INSTANCE_IDENTIFIER } from '../generator';
 import type { Runner } from '../runner';
 import { Checks } from './Checks';
 import { Randomization } from './Randomization';
@@ -59,6 +61,32 @@ export class Utils {
 	) {
 		if (!schema || schema._def.typeName === 'ZodNever') return;
 		assignment(schema);
+	}
+
+	isType<TSchema extends ZodTypeAny>(
+		target: ZodConstructorOrSchema<TSchema> | undefined,
+		schema: ZodTypeAny
+	): schema is TSchema {
+		if (!target) return false;
+
+		if (isZodConstructor(target)) {
+			if (schema._def.typeName !== target.name) {
+				return false;
+			}
+		} else {
+			if (schema._def.typeName !== target._def.typeName) {
+				return false;
+			}
+
+			// If our generator was created with an instance, make sure it matches
+			// the schema we're trying to generate.
+			// This is particularly important for z.custom schemas.
+			if (schema[ZOD_INSTANCE_IDENTIFIER] !== undefined) {
+				if (schema[ZOD_INSTANCE_IDENTIFIER] !== target[ZOD_INSTANCE_IDENTIFIER])
+					return false;
+			}
+		}
+		return true;
 	}
 
 	checks<TChecks extends { kind: string }[]>(checks: TChecks) {


### PR DESCRIPTION
This is a new proposal to make generator schemas optional.

```ts
Generator({
  output: () => 'everything matched'
})
```

In the case where a schema is not provided, the type signatures of the checks are no longer known. The `checks` util has been updated to reflect this and now returns `unknown` in that scenario. It's an exercise for the user to define what that shape should be.

```ts
Generator({
  output: ({ transform, def }) => {
    const checks = tranform.utils.checks(def.checks)
    const max = checks.find('max') // this is now unknown because the Zod type is unknown.
  }
})
```