### PR TITLE
Support Additional Recursion Wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Creating test fixtures should be easy.<br>
 - [Customizing](#customizing)
   - [Extending](#extending)
   - [Generators](#generators)
-    - [Matching](#matching)
+    - [Schema](#schema)
     - [Filtering](#filtering)
       - [Filter by Check](#filter-by-check)
       - [Filter by Key](#filter-by-key)
@@ -234,16 +234,16 @@ To generate a value based on a zod type we're using what we call a `Generator`.
 
 A `Generator` has 3 fundamental parts:
 
-- [schema](#matching) -- the zod type to match
+- [schema](#schema) -- [optional] the zod type to match
 - [filter](#filtering) -- [optional] a function to further refine our match (ie filtering by keys or zod checks)
 - [output](#output) -- a function that's called to produce the fixture
 
-#### Matching
+#### Schema
 
-All generators require a `zod` schema to match against. A schema can be provided in the following ways:
+A schema can be provided in the following ways:
 
 - A zod type constructor (ie `ZodString`)
-- An instance of a type (typically `z.custom`)
+- An instance of a type (ie `z.custom()`)
 
 <sub>[Example](https://github.com/timdeschryver/zod-fixture/tree/main/examples/generator-schema-matching.test.ts)</sub>
 
@@ -300,7 +300,7 @@ In addition to matching schemas, `zod-fixture` provides robust tools for filteri
 
 ##### Filter by Check
 
-In the case where you use a `zod` method like `z.string().email()`, `zod` adds what they call a "check" to the defintion. These are additional constraints that are checked during parsing that don't conform to a Typescript type. (ie TS does not have the concept of an email, just a string). `zod-fixture` provides a type safe utility called `checks` for interacting with these additional constraints.
+In the case where you use a `zod` method like `z.string().email()`, `zod` adds what they call a "check" to the definition. These are additional constraints that are checked during parsing that don't conform to a Typescript type. (ie TS does not have the concept of an email, just a string). `zod-fixture` provides a type safe utility called `checks` for interacting with these additional constraints.
 
 There are two methods provided by the `checks` utility:
 

--- a/README.md
+++ b/README.md
@@ -612,6 +612,10 @@ interface Defaults {
 		max: number;
 		characterSet: string;
 	};
+	recursion: {
+		min: number;
+		max: number;
+	};
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,16 +83,16 @@ To generate a value based on a zod type we're using what we call a `Generator`.
 
 A `Generator` has 3 fundamental parts:
 
-- [schema](#matching) -- the zod type to match
+- [schema](#schema) -- [optional] the zod type to match
 - [filter](#filtering) -- [optional] a function to further refine our match (ie filtering by keys or zod checks)
 - [output](#output) -- a function that's called to produce the fixture
 
-#### Matching
+#### Schema
 
-All generators require a `zod` schema to match against. A schema can be provided in the following ways:
+A schema can be provided in the following ways:
 
 - A zod type constructor (ie `ZodString`)
-- An instance of a type (typically `z.custom`)
+- An instance of a type (ie `z.custom()`)
 
 ::: code-group
 <<< @/../examples/generator-schema-matching.test.ts#example [Example]
@@ -105,7 +105,7 @@ In addition to matching schemas, `zod-fixture` provides robust tools for filteri
 
 ##### Filter by Check
 
-In the case where you use a `zod` method like `z.string().email()`, `zod` adds what they call a "check" to the defintion. These are additional constraints that are checked during parsing that don't conform to a Typescript type. (ie TS does not have the concept of an email, just a string). `zod-fixture` provides a type safe utility called `checks` for interacting with these additional constraints.
+In the case where you use a `zod` method like `z.string().email()`, `zod` adds what they call a "check" to the definition. These are additional constraints that are checked during parsing that don't conform to a Typescript type. (ie TS does not have the concept of an email, just a string). `zod-fixture` provides a type safe utility called `checks` for interacting with these additional constraints.
 
 There are two methods provided by the `checks` utility:
 

--- a/src/fixture/generators/array/index.ts
+++ b/src/fixture/generators/array/index.ts
@@ -24,13 +24,18 @@ export const ArrayGenerator = Generator({
 		const result: unknown[] = [];
 
 		transform.utils.ifNotNever(def.type, (schema) => {
-			transform.utils.n(
-				(key) =>
-					result.push(
-						transform.fromSchema(schema, { path: [...context.path, key] })
-					),
-				{ min, max }
-			);
+			transform.utils.recursionCheck(schema, () => {
+				transform.utils.n(
+					(key) =>
+						result.push(
+							transform.fromSchema(schema, {
+								...context,
+								path: [...context.path, key],
+							})
+						),
+					{ min, max }
+				);
+			});
 		});
 
 		return result;

--- a/src/fixture/generators/lazy/index.ts
+++ b/src/fixture/generators/lazy/index.ts
@@ -3,6 +3,10 @@ import { Generator } from '@/transformer/generator';
 
 export const LazyGenerator = Generator({
 	schema: ZodLazy,
-	output: ({ def, transform, context }) =>
-		transform.fromSchema(def.getter(), context),
+	output: ({ def, transform, context }) => {
+		const count = transform.utils.recursion.get(def.getter) ?? 0;
+		transform.utils.recursion.set(def.getter, count + 1);
+
+		return transform.fromSchema(def.getter(), context);
+	},
 });

--- a/src/fixture/generators/lazy/lazy.test.ts
+++ b/src/fixture/generators/lazy/lazy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import { LazyGenerator } from '.';
 import { ArrayGenerator } from '../array';
+import { NullableGenerator } from '../nullable';
 import { ObjectGenerator } from '../object';
 import { StringGenerator } from '../string';
 
@@ -12,6 +13,7 @@ describe('create a lazy type', () => {
 		StringGenerator,
 		ObjectGenerator,
 		ArrayGenerator,
+		NullableGenerator,
 	]);
 
 	test('should handle recursive schemas', () => {
@@ -20,11 +22,11 @@ describe('create a lazy type', () => {
 		});
 
 		type Category = z.infer<typeof baseCategorySchema> & {
-			subcategories: Category[];
+			subcategories?: Category[] | null;
 		};
 
 		const categorySchema: z.ZodType<Category> = baseCategorySchema.extend({
-			subcategories: z.lazy(() => categorySchema.array()),
+			subcategories: z.lazy(() => categorySchema.array()).nullable(),
 		});
 
 		expect(() => transform.fromSchema(categorySchema)).not.toThrowError();
@@ -37,20 +39,25 @@ describe('create a lazy type', () => {
 			      "subcategories": [
 			        {
 			          "name": "zfvvt-vicsnxxyw",
+			          "subcategories": null,
 			        },
 			        {
 			          "name": "bhebxscqlszlofs",
+			          "subcategories": null,
 			        },
 			        {
 			          "name": "dsvwlaauq-ruihm",
+			          "subcategories": null,
 			        },
 			      ],
 			    },
 			    {
 			      "name": "cbmmychyhddoacs",
+			      "subcategories": null,
 			    },
 			    {
 			      "name": "yhinpbppqdzphsg",
+			      "subcategories": null,
 			    },
 			  ],
 			}

--- a/src/fixture/generators/lazy/lazy.test.ts
+++ b/src/fixture/generators/lazy/lazy.test.ts
@@ -7,7 +7,7 @@ import { ObjectGenerator } from '../object';
 import { StringGenerator } from '../string';
 
 describe('create a lazy type', () => {
-	const transform = new ConstrainedTransformer().extend([
+	const transform = new ConstrainedTransformer({ seed: 1 }).extend([
 		LazyGenerator,
 		StringGenerator,
 		ObjectGenerator,
@@ -30,27 +30,27 @@ describe('create a lazy type', () => {
 		expect(() => transform.fromSchema(categorySchema)).not.toThrowError();
 		expect(transform.fromSchema(categorySchema)).toMatchInlineSnapshot(`
 			{
-			  "name": "nqypkamrvcwbasg",
+			  "name": "-tzadi-dgckfkjs",
 			  "subcategories": [
 			    {
-			      "name": "pieit-nuhlrghez",
+			      "name": "wlisoflxgaosylm",
 			      "subcategories": [
 			        {
-			          "name": "lrcthqxrfsogtdx",
+			          "name": "zfvvt-vicsnxxyw",
 			        },
 			        {
-			          "name": "agkbtrdoeqmftdy",
+			          "name": "bhebxscqlszlofs",
 			        },
 			        {
-			          "name": "vliwuslzsvnuzjc",
+			          "name": "dsvwlaauq-ruihm",
 			        },
 			      ],
 			    },
 			    {
-			      "name": "ycofjjjoqqnugmh",
+			      "name": "cbmmychyhddoacs",
 			    },
 			    {
-			      "name": "nxgqrmammw-nvbz",
+			      "name": "yhinpbppqdzphsg",
 			    },
 			  ],
 			}

--- a/src/fixture/generators/lazy/lazy.test.ts
+++ b/src/fixture/generators/lazy/lazy.test.ts
@@ -2,19 +2,58 @@ import { ConstrainedTransformer } from '@/transformer/transformer';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import { LazyGenerator } from '.';
-import { NumberGenerator } from '../number';
+import { ArrayGenerator } from '../array';
+import { ObjectGenerator } from '../object';
+import { StringGenerator } from '../string';
 
 describe('create a lazy type', () => {
 	const transform = new ConstrainedTransformer().extend([
 		LazyGenerator,
-		NumberGenerator,
+		StringGenerator,
+		ObjectGenerator,
+		ArrayGenerator,
 	]);
 
-	test('produces a valid lazy', () => {
-		expect(transform).toReasonablySatisfy(z.lazy(() => z.number()));
-	});
+	test('should handle recursive schemas', () => {
+		const baseCategorySchema = z.object({
+			name: z.string(),
+		});
 
-	test('creates a promise with the correct type', () => {
-		expect(transform.fromSchema(z.lazy(() => z.number()))).toBeTypeOf('number');
+		type Category = z.infer<typeof baseCategorySchema> & {
+			subcategories: Category[];
+		};
+
+		const categorySchema: z.ZodType<Category> = baseCategorySchema.extend({
+			subcategories: z.lazy(() => categorySchema.array()),
+		});
+
+		expect(() => transform.fromSchema(categorySchema)).not.toThrowError();
+		expect(transform.fromSchema(categorySchema)).toMatchInlineSnapshot(`
+			{
+			  "name": "nqypkamrvcwbasg",
+			  "subcategories": [
+			    {
+			      "name": "pieit-nuhlrghez",
+			      "subcategories": [
+			        {
+			          "name": "lrcthqxrfsogtdx",
+			        },
+			        {
+			          "name": "agkbtrdoeqmftdy",
+			        },
+			        {
+			          "name": "vliwuslzsvnuzjc",
+			        },
+			      ],
+			    },
+			    {
+			      "name": "ycofjjjoqqnugmh",
+			    },
+			    {
+			      "name": "nxgqrmammw-nvbz",
+			    },
+			  ],
+			}
+		`);
 	});
 });

--- a/src/fixture/generators/map/index.ts
+++ b/src/fixture/generators/map/index.ts
@@ -12,14 +12,19 @@ export const MapGenerator = Generator({
 
 		transform.utils.ifNotNever(key, (keySchema) => {
 			transform.utils.ifNotNever(value, (valueSchema) => {
-				transform.utils.n(() => {
-					const k = transform.fromSchema(keySchema, context) as string | number;
-					const v = transform.fromSchema(valueSchema, {
-						path: [...context.path, k],
-					});
+				transform.utils.recursionCheck(valueSchema, () => {
+					transform.utils.n(() => {
+						const k = transform.fromSchema(keySchema, context) as
+							| string
+							| number;
+						const v = transform.fromSchema(valueSchema, {
+							...context,
+							path: [...context.path, k],
+						});
 
-					map.set(k, v);
-				}, transform.defaults.map);
+						map.set(k, v);
+					}, transform.defaults.map);
+				});
 			});
 		});
 

--- a/src/fixture/generators/nullable/index.ts
+++ b/src/fixture/generators/nullable/index.ts
@@ -3,6 +3,13 @@ import { Generator } from '@/transformer/generator';
 
 export const NullableGenerator = Generator({
 	schema: ZodNullable,
-	output: ({ def, transform, context }) =>
-		transform.fromSchema(def.innerType, context),
+	output: ({ def, transform, context }) => {
+		let result = null;
+
+		transform.utils.recursionCheck(def.innerType, () => {
+			result = transform.fromSchema(def.innerType, context);
+		});
+
+		return result;
+	},
 });

--- a/src/fixture/generators/object/index.ts
+++ b/src/fixture/generators/object/index.ts
@@ -10,8 +10,11 @@ export const ObjectGenerator = Generator({
 
 		for (const key in shape) {
 			transform.utils.ifNotNever(shape[key], (schema) => {
-				result[key] = transform.fromSchema(schema, {
-					path: [...context.path, key],
+				transform.utils.recursionCheck(schema, () => {
+					result[key] = transform.fromSchema(schema, {
+						...context,
+						path: [...context.path, key],
+					});
 				});
 			});
 		}
@@ -26,6 +29,7 @@ export const ObjectGenerator = Generator({
 					? ZodAny.create()
 					: def.catchall;
 			result[key] = transform.fromSchema(type, {
+				...context,
 				path: [...context.path, key],
 			});
 		}
@@ -44,13 +48,18 @@ export const RecordGenerator = Generator({
 
 		transform.utils.ifNotNever(def.keyType, (keyType) => {
 			transform.utils.ifNotNever(def.valueType, (valueType) => {
-				transform.utils.n(() => {
-					const key = transform.fromSchema(keyType, context) as string | number;
-					const value = transform.fromSchema(valueType, {
-						path: [...context.path, key],
-					});
+				transform.utils.recursionCheck(valueType, () => {
+					transform.utils.n(() => {
+						const key = transform.fromSchema(keyType, context) as
+							| string
+							| number;
+						const value = transform.fromSchema(valueType, {
+							...context,
+							path: [...context.path, key],
+						});
 
-					result[key] = value;
+						result[key] = value;
+					});
 				});
 			});
 		});

--- a/src/fixture/generators/optional/index.ts
+++ b/src/fixture/generators/optional/index.ts
@@ -3,6 +3,13 @@ import { Generator } from '@/transformer/generator';
 
 export const OptionalGenerator = Generator({
 	schema: ZodOptional,
-	output: ({ def, transform, context }) =>
-		transform.fromSchema(def.innerType, context),
+	output: ({ def, transform, context }) => {
+		let result = undefined;
+
+		transform.utils.recursionCheck(def.innerType, () => {
+			result = transform.fromSchema(def.innerType, context);
+		});
+
+		return result;
+	},
 });

--- a/src/fixture/generators/promise/index.ts
+++ b/src/fixture/generators/promise/index.ts
@@ -3,6 +3,15 @@ import { Generator } from '@/transformer/generator';
 
 export const PromiseGenerator = Generator({
 	schema: ZodPromise,
-	output: ({ def, transform, context }) =>
-		Promise.resolve(transform.fromSchema(def.type, context)),
+	output: ({ def, transform, context }) => {
+		// TODO: this fallback isn't correct but architecting something that is
+		// would probably be a major refactor.
+		let result = undefined;
+
+		transform.utils.recursionCheck(def.type, () => {
+			result = transform.fromSchema(def.type, context);
+		});
+
+		return Promise.resolve(result);
+	},
 });

--- a/src/fixture/generators/set/index.ts
+++ b/src/fixture/generators/set/index.ts
@@ -25,16 +25,19 @@ export const SetGenerator = Generator({
 		const result = new Set<z.infer<typeof def.valueType>>();
 
 		transform.utils.ifNotNever(def.valueType, (valueType) => {
-			transform.utils.n(
-				() => {
-					result.add(
-						transform.fromSchema(valueType, {
-							path: [...context.path, result.size],
-						})
-					);
-				},
-				{ min, max }
-			);
+			transform.utils.recursionCheck(valueType, () => {
+				transform.utils.n(
+					() => {
+						result.add(
+							transform.fromSchema(valueType, {
+								...context,
+								path: [...context.path, result.size],
+							})
+						);
+					},
+					{ min, max }
+				);
+			});
 		});
 
 		return result;

--- a/src/fixture/generators/tuple/index.ts
+++ b/src/fixture/generators/tuple/index.ts
@@ -8,24 +8,32 @@ export const TupleGenerator = Generator({
 
 		def.items.forEach((type, idx) => {
 			transform.utils.ifNotNever(type, (schema) => {
-				known.push(
-					transform.fromSchema(schema, { path: [...context.path, idx] })
-				);
+				transform.utils.recursionCheck(schema, () => {
+					known.push(
+						transform.fromSchema(schema, {
+							...context,
+							path: [...context.path, idx],
+						})
+					);
+				});
 			});
 		});
 
 		const rest: unknown[] = [];
 
 		transform.utils.ifNotNever(def.rest, (schema) => {
-			transform.utils.n(
-				(idx) =>
-					rest.push(
-						transform.fromSchema(schema, {
-							path: [...context.path, known.length + idx],
-						})
-					),
-				1
-			);
+			transform.utils.recursionCheck(schema, () => {
+				transform.utils.n(
+					(idx) =>
+						rest.push(
+							transform.fromSchema(schema, {
+								...context,
+								path: [...context.path, known.length + idx],
+							})
+						),
+					1
+				);
+			});
 		});
 
 		return [...known, ...rest];

--- a/src/transformer/defaults.ts
+++ b/src/transformer/defaults.ts
@@ -83,8 +83,8 @@ export const constrained = {
 		characterSet: 'abcdefghijklmnopqrstuvwxyz-',
 	},
 	recursion: {
-		min: 1,
-		max: 1,
+		min: 2,
+		max: 2,
 	},
 } satisfies Defaults;
 

--- a/src/transformer/defaults.ts
+++ b/src/transformer/defaults.ts
@@ -34,6 +34,10 @@ interface Defaults {
 		max: number;
 		characterSet: string;
 	};
+	recursion: {
+		min: number;
+		max: number;
+	};
 }
 // #endregion defaults
 
@@ -78,6 +82,10 @@ export const constrained = {
 		max: 15,
 		characterSet: 'abcdefghijklmnopqrstuvwxyz-',
 	},
+	recursion: {
+		min: 1,
+		max: 1,
+	},
 } satisfies Defaults;
 
 export const unconstrained = {
@@ -114,6 +122,10 @@ export const unconstrained = {
 		max: 100,
 		characterSet:
 			'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.,/\\!@#$%^&*()_+=-{}[]|:;?<>~`\'"',
+	},
+	recursion: {
+		min: MIN_LIST_SIZE,
+		max: MAX_LIST_SIZE,
 	},
 } satisfies Defaults;
 

--- a/src/transformer/generator.ts
+++ b/src/transformer/generator.ts
@@ -1,14 +1,6 @@
 import type { ZodTypeAny } from 'zod';
 import type { Runner } from './runner';
 
-export const ZOD_INSTANCE_IDENTIFIER = Symbol('ZOD_INSTANCE_IDENTIFIER');
-
-declare module 'zod' {
-	interface ZodType {
-		[ZOD_INSTANCE_IDENTIFIER]?: number;
-	}
-}
-
 // #region context
 export interface Context {
 	path: (string | number)[];
@@ -33,7 +25,8 @@ export function isZodConstructor(
 }
 
 // #region filter
-type Filter<TSchema extends ZodTypeAny = ZodTypeAny> = (obj: {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Filter<TSchema extends ZodTypeAny = any> = (obj: {
 	def: TSchema['_def'];
 	schema: TSchema;
 	transform: Runner;
@@ -41,31 +34,26 @@ type Filter<TSchema extends ZodTypeAny = ZodTypeAny> = (obj: {
 }) => boolean;
 // #endregion filter
 
-export type Generator<TSchema extends ZodTypeAny = ZodTypeAny> = (obj: {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Generator<TSchema extends ZodTypeAny = any> = (obj: {
 	def: TSchema['_def'];
 	schema: TSchema;
 	transform: Runner;
 	context: Context;
 }) => unknown;
 
-export interface Definition<TSchema extends ZodTypeAny = ZodTypeAny> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Definition<TSchema extends ZodTypeAny = any> {
 	schema?: ZodConstructorOrSchema<TSchema>;
 	filter?: Filter<TSchema>;
 	output: Generator<TSchema>;
 }
 
-export function Generator<TSchema extends ZodTypeAny = ZodTypeAny>(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function Generator<TSchema extends ZodTypeAny = any>(
 	definition: Definition<TSchema>
 ): Definition<TSchema> {
-	if (definition.schema !== undefined) {
-		if (!isZodConstructor(definition.schema)) {
-			if (definition.schema[ZOD_INSTANCE_IDENTIFIER] === undefined)
-				definition.schema[ZOD_INSTANCE_IDENTIFIER] = Generator.uuid++;
-		}
-	}
-
 	return definition;
 }
-Generator.uuid = 0;
 
 export type { Filter };

--- a/src/transformer/runner.ts
+++ b/src/transformer/runner.ts
@@ -28,7 +28,10 @@ export class Runner {
 		const transform = this;
 		const def = schema._def;
 		const generator = this.transformer.generators.find((generator) => {
-			if (!transform.utils.isType(generator.schema, schema)) {
+			if (
+				generator.schema &&
+				!transform.utils.isType(generator.schema, schema)
+			) {
 				return false;
 			}
 

--- a/src/transformer/utils/index.ts
+++ b/src/transformer/utils/index.ts
@@ -72,7 +72,7 @@ export class Utils {
 		if (this.isType(ZodLazy, schema)) {
 			const count = this.recursion.get(schema._def.getter) ?? 0;
 			const cap = this.random.int(this.runner.defaults.recursion);
-			if (count > cap) return;
+			if (count >= cap) return;
 		}
 		action(schema);
 	}

--- a/src/transformer/utils/index.ts
+++ b/src/transformer/utils/index.ts
@@ -1,11 +1,13 @@
+import { ZodLazy } from '@/internal/zod';
 import type { ZodTypeAny } from 'zod';
 import type { ZodConstructorOrSchema } from '../generator';
-import { isZodConstructor, ZOD_INSTANCE_IDENTIFIER } from '../generator';
+import { isZodConstructor } from '../generator';
 import type { Runner } from '../runner';
 import { Checks } from './Checks';
 import { Randomization } from './Randomization';
 
 export class Utils {
+	recursion = new WeakMap<() => ZodTypeAny, number>();
 	random: Randomization;
 
 	constructor(private runner: Runner) {
@@ -57,36 +59,34 @@ export class Utils {
 
 	ifNotNever<TSchema extends ZodTypeAny>(
 		schema: TSchema | null | undefined,
-		assignment: (schema: TSchema) => unknown
+		action: (schema: TSchema) => unknown
 	) {
 		if (!schema || schema._def.typeName === 'ZodNever') return;
-		assignment(schema);
+		action(schema);
+	}
+
+	recursionCheck<TSchema extends ZodTypeAny>(
+		schema: TSchema,
+		action: (schema: TSchema) => unknown
+	) {
+		if (this.isType(ZodLazy, schema)) {
+			const count = this.recursion.get(schema._def.getter) ?? 0;
+			const cap = this.random.int(this.runner.defaults.recursion);
+			if (count > cap) return;
+		}
+		action(schema);
 	}
 
 	isType<TSchema extends ZodTypeAny>(
-		target: ZodConstructorOrSchema<TSchema> | undefined,
+		target: ZodConstructorOrSchema<TSchema>,
 		schema: ZodTypeAny
 	): schema is TSchema {
-		if (!target) return false;
-
-		if (isZodConstructor(target)) {
-			if (schema._def.typeName !== target.name) {
-				return false;
-			}
-		} else {
-			if (schema._def.typeName !== target._def.typeName) {
-				return false;
-			}
-
-			// If our generator was created with an instance, make sure it matches
-			// the schema we're trying to generate.
-			// This is particularly important for z.custom schemas.
-			if (schema[ZOD_INSTANCE_IDENTIFIER] !== undefined) {
-				if (schema[ZOD_INSTANCE_IDENTIFIER] !== target[ZOD_INSTANCE_IDENTIFIER])
-					return false;
-			}
-		}
-		return true;
+		return isZodConstructor(target)
+			? schema._def.typeName === target.name
+			: // If our generator was created with an instance, make sure it matches
+			  // the schema we're trying to generate.
+			  // This is particularly important for z.custom schemas.
+			  schema === target;
 	}
 
 	checks<TChecks extends { kind: string }[]>(checks: TChecks) {

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -1,12 +1,11 @@
-import { Fixture, Generator, Transformer } from '@/public';
-import { ZOD_INSTANCE_IDENTIFIER } from '@/transformer/generator';
+import { createFixture, Fixture, Generator, Transformer } from '@/public';
 import MersenneTwister from '@/transformer/utils/MersenneTwister';
 import { z } from 'zod';
 
 Object.assign(window, {
+	createFixture,
 	Generator,
 	Transformer,
-	ZOD_INSTANCE_IDENTIFIER,
 	MersenneTwister,
 	Fixture,
 	z,


### PR DESCRIPTION
There were still some edge cases with recursion that included methods like `nullable`, `optional`, and `promise`.

```ts
z.lazy(() => categorySchema.array()).nullable()
```

Full example below.

```ts
const baseCategorySchema = z.object({
	name: z.string(),
});

type Category = z.infer<typeof baseCategorySchema> & {
	subcategories?: Category[] | null;
};

const categorySchema: z.ZodType<Category> = baseCategorySchema.extend({
	subcategories: z.lazy(() => categorySchema.array()).nullable(),
});
```
