### PR TITLE
Optimized Build Size

### DIFF
--- a/src/fixture/fixture.ts
+++ b/src/fixture/fixture.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { InferZodType, ZodTypeAny } from '@/internal/zod';
 import type { Defaults } from '../transformer/defaults';
 import {
 	ConstrainedTransformer,
@@ -6,7 +6,7 @@ import {
 } from '../transformer/transformer';
 import { DEFAULT_FIXTURE_GENERATORS } from './generators';
 
-function missingGeneratorError(schema: z.ZodTypeAny) {
+function missingGeneratorError(schema: ZodTypeAny) {
 	const message = [
 		`No generator found for ${schema.constructor.name}.`,
 		'',
@@ -20,10 +20,10 @@ function missingGeneratorError(schema: z.ZodTypeAny) {
 
 export interface ConstrainedFixture extends ConstrainedTransformer {
 	// explicitly define the return type
-	fromSchema<TSchema extends z.ZodTypeAny>(
+	fromSchema<TSchema extends ZodTypeAny>(
 		schema: TSchema,
-		instanceDefaults?: Partial<Defaults>
-	): z.infer<TSchema>;
+		instanceDefaults?: Partial<Defaults>,
+	): InferZodType<TSchema>;
 }
 
 export class ConstrainedFixture extends ConstrainedTransformer {
@@ -33,10 +33,10 @@ export class ConstrainedFixture extends ConstrainedTransformer {
 
 export interface UnconstrainedFixture extends UnconstrainedTransformer {
 	// explicitly define the return type
-	fromSchema<TSchema extends z.ZodTypeAny>(
+	fromSchema<TSchema extends ZodTypeAny>(
 		schema: TSchema,
-		instanceDefaults?: Partial<Defaults>
-	): z.infer<TSchema>;
+		instanceDefaults?: Partial<Defaults>,
+	): InferZodType<TSchema>;
 }
 
 export class UnconstrainedFixture extends UnconstrainedTransformer {
@@ -46,9 +46,9 @@ export class UnconstrainedFixture extends UnconstrainedTransformer {
 
 export { ConstrainedFixture as Fixture };
 
-export function createFixture<TSchema extends z.ZodTypeAny>(
+export function createFixture<TSchema extends ZodTypeAny>(
 	schema: TSchema,
-	instanceDefaults?: Partial<Defaults>
-): z.infer<TSchema> {
+	instanceDefaults?: Partial<Defaults>,
+): InferZodType<TSchema> {
 	return new ConstrainedFixture(instanceDefaults).fromSchema(schema);
 }

--- a/src/fixture/generators/intersection/index.ts
+++ b/src/fixture/generators/intersection/index.ts
@@ -1,7 +1,10 @@
-import { ZodIntersection } from '@/internal/zod';
+import {
+	ZodIntersection,
+	ZodParsedType,
+	getParsedType,
+	util,
+} from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
-// @TODO: refactor so we don't have to bundle zod
-import { ZodParsedType, getParsedType, util } from 'zod';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const IntersectionGenerator = Generator({
@@ -21,7 +24,7 @@ export const IntersectionGenerator = Generator({
  */
 function mergeValues(
 	a: any,
-	b: any
+	b: any,
 ): { valid: true; data: any } | { valid: false } {
 	const aType = getParsedType(a);
 	const bType = getParsedType(b);

--- a/src/fixture/generators/map/index.ts
+++ b/src/fixture/generators/map/index.ts
@@ -1,4 +1,4 @@
-import type { TypeOf } from '@/internal/zod';
+import type { InferZodType } from '@/internal/zod';
 import { ZodMap } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
 
@@ -8,7 +8,7 @@ export const MapGenerator = Generator({
 		const key = def.keyType;
 		const value = def.valueType;
 
-		const map = new Map<TypeOf<typeof key>, TypeOf<typeof value>>();
+		const map = new Map<InferZodType<typeof key>, InferZodType<typeof value>>();
 
 		transform.utils.ifNotNever(key, (keySchema) => {
 			transform.utils.ifNotNever(value, (valueSchema) => {

--- a/src/fixture/generators/map/index.ts
+++ b/src/fixture/generators/map/index.ts
@@ -1,6 +1,6 @@
+import type { TypeOf } from '@/internal/zod';
 import { ZodMap } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
-import type { z } from 'zod';
 
 export const MapGenerator = Generator({
 	schema: ZodMap,
@@ -8,7 +8,7 @@ export const MapGenerator = Generator({
 		const key = def.keyType;
 		const value = def.valueType;
 
-		const map = new Map<z.infer<typeof key>, z.infer<typeof value>>();
+		const map = new Map<TypeOf<typeof key>, TypeOf<typeof value>>();
 
 		transform.utils.ifNotNever(key, (keySchema) => {
 			transform.utils.ifNotNever(value, (valueSchema) => {

--- a/src/fixture/generators/object/index.ts
+++ b/src/fixture/generators/object/index.ts
@@ -1,4 +1,4 @@
-import type { TypeOf } from '@/internal/zod';
+import type { InferZodType } from '@/internal/zod';
 import { ZodAny, ZodObject, ZodRecord } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
 
@@ -42,8 +42,8 @@ export const RecordGenerator = Generator({
 	schema: ZodRecord,
 	output: ({ def, transform, context }) => {
 		const result: Record<
-			TypeOf<typeof def.keyType>,
-			TypeOf<typeof def.valueType>
+			InferZodType<typeof def.keyType>,
+			InferZodType<typeof def.valueType>
 		> = {};
 
 		transform.utils.ifNotNever(def.keyType, (keyType) => {

--- a/src/fixture/generators/object/index.ts
+++ b/src/fixture/generators/object/index.ts
@@ -1,6 +1,6 @@
+import type { TypeOf } from '@/internal/zod';
 import { ZodAny, ZodObject, ZodRecord } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
-import type { z } from 'zod';
 
 export const ObjectGenerator = Generator({
 	schema: ZodObject,
@@ -42,8 +42,8 @@ export const RecordGenerator = Generator({
 	schema: ZodRecord,
 	output: ({ def, transform, context }) => {
 		const result: Record<
-			z.infer<typeof def.keyType>,
-			z.infer<typeof def.valueType>
+			TypeOf<typeof def.keyType>,
+			TypeOf<typeof def.valueType>
 		> = {};
 
 		transform.utils.ifNotNever(def.keyType, (keyType) => {

--- a/src/fixture/generators/set/index.ts
+++ b/src/fixture/generators/set/index.ts
@@ -1,7 +1,7 @@
 import { ZodSet } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
 
-import type { TypeOf } from '@/internal/zod';
+import type { InferZodType } from '@/internal/zod';
 
 export const SetGenerator = Generator({
 	schema: ZodSet,
@@ -23,7 +23,7 @@ export const SetGenerator = Generator({
 			resolve: (options) => Math.max(options.fallback, options.conflict),
 		});
 
-		const result = new Set<TypeOf<typeof def.valueType>>();
+		const result = new Set<InferZodType<typeof def.valueType>>();
 
 		transform.utils.ifNotNever(def.valueType, (valueType) => {
 			transform.utils.recursionCheck(valueType, () => {

--- a/src/fixture/generators/set/index.ts
+++ b/src/fixture/generators/set/index.ts
@@ -1,6 +1,7 @@
 import { ZodSet } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
-import type { z } from 'zod';
+
+import type { TypeOf } from '@/internal/zod';
 
 export const SetGenerator = Generator({
 	schema: ZodSet,
@@ -22,7 +23,7 @@ export const SetGenerator = Generator({
 			resolve: (options) => Math.max(options.fallback, options.conflict),
 		});
 
-		const result = new Set<z.infer<typeof def.valueType>>();
+		const result = new Set<TypeOf<typeof def.valueType>>();
 
 		transform.utils.ifNotNever(def.valueType, (valueType) => {
 			transform.utils.recursionCheck(valueType, () => {
@@ -32,10 +33,10 @@ export const SetGenerator = Generator({
 							transform.fromSchema(valueType, {
 								...context,
 								path: [...context.path, result.size],
-							})
+							}),
 						);
 					},
-					{ min, max }
+					{ min, max },
 				);
 			});
 		});

--- a/src/fixture/generators/string/index.ts
+++ b/src/fixture/generators/string/index.ts
@@ -1,7 +1,7 @@
+import type { ZodStringDef } from '@/internal/zod';
 import { ZodString } from '@/internal/zod';
 import { Generator } from '@/transformer/generator';
 import type { Runner } from '@/transformer/runner';
-import type { ZodStringDef } from 'zod';
 
 const prefixPattern = (str: string) => `^.{${str.length}}`;
 const suffixPattern = (str: string) => `.{${str.length}}$`;
@@ -38,7 +38,7 @@ function formatString(transform: Runner, def: ZodStringDef, value: string) {
 		const prefix = startsWith ? prefixPattern(startsWith) : '';
 		value = value.replace(
 			new RegExp(`(${prefix}).{${includes.length}}`),
-			(_, prefix) => prefix + includes
+			(_, prefix) => prefix + includes,
 		);
 	}
 
@@ -84,7 +84,7 @@ export const StringGenerator = Generator({
 		return formatString(
 			transform,
 			def,
-			transform.utils.random.string({ min, max })
+			transform.utils.random.string({ min, max }),
 		);
 	},
 });
@@ -104,7 +104,7 @@ export const UrlGenerator = Generator({
 		return formatString(
 			transform,
 			def,
-			`https://${transform.utils.random.lorem(1)}.com`
+			`https://${transform.utils.random.lorem(1)}.com`,
 		);
 	},
 });
@@ -149,7 +149,7 @@ export const IpGenerator = Generator({
 		return transform.utils
 			.n(
 				() => transform.utils.random.int({ min: 0, max: 65535 }).toString(16),
-				8
+				8,
 			)
 			.join(':');
 	},

--- a/src/internal/zod.ts
+++ b/src/internal/zod.ts
@@ -190,6 +190,6 @@ export const util = {
 			  },
 };
 
-export type TypeOf<T extends { _output: unknown }> = T['_output'];
+export type InferZodType<T extends { _output: unknown }> = T['_output'];
 export type { ZodStringDef, ZodTypeAny };
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/transformer/generator.ts
+++ b/src/transformer/generator.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from '@/internal/zod';
 import type { Runner } from './runner';
 
 // #region context
@@ -19,7 +19,7 @@ export type ZodConstructorOrSchema<TSchema extends ZodTypeAny> =
 	| ZodConstructor<TSchema>;
 
 export function isZodConstructor(
-	schema: ZodConstructorOrSchema<ZodTypeAny>
+	schema: ZodConstructorOrSchema<ZodTypeAny>,
 ): schema is ZodConstructor<ZodTypeAny> {
 	return typeof schema === 'function';
 }
@@ -51,7 +51,7 @@ export interface Definition<TSchema extends ZodTypeAny = any> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Generator<TSchema extends ZodTypeAny = any>(
-	definition: Definition<TSchema>
+	definition: Definition<TSchema>,
 ): Definition<TSchema> {
 	return definition;
 }

--- a/src/transformer/runner.ts
+++ b/src/transformer/runner.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from '@/internal/zod';
 import type { Defaults } from './defaults';
 import type { Context } from './generator';
 import type { Transformer } from './transformer';
@@ -10,7 +10,7 @@ export class Runner {
 
 	constructor(
 		public readonly transformer: Transformer,
-		schemaDefaults?: Partial<Defaults>
+		schemaDefaults?: Partial<Defaults>,
 	) {
 		this.defaults = {
 			...transformer.transformerDefaults,
@@ -22,7 +22,7 @@ export class Runner {
 
 	fromSchema<TSchema extends ZodTypeAny>(
 		schema: TSchema,
-		context: Context = { path: [] }
+		context: Context = { path: [] },
 	): unknown {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const transform = this;
@@ -52,7 +52,7 @@ export class Runner {
 
 	shouldHaveMatch(
 		schema: ZodTypeAny,
-		generator: unknown
+		generator: unknown,
 	): asserts generator is NonNullable<unknown> {
 		if (!generator) throw this.transformer.missingGeneratorError(schema);
 	}

--- a/src/transformer/transformer.ts
+++ b/src/transformer/transformer.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny } from 'zod';
+import type { ZodTypeAny } from '@/internal/zod';
 import type { Defaults } from './defaults';
 import { constrained, randomSeed, unconstrained } from './defaults';
 import type { Definition } from './generator';
@@ -24,7 +24,7 @@ export abstract class Transformer {
 
 	fromSchema<TSchema extends ZodTypeAny>(
 		schema: TSchema,
-		instanceDefaults?: Partial<Defaults>
+		instanceDefaults?: Partial<Defaults>,
 	): unknown {
 		return new Runner(this, instanceDefaults).fromSchema(schema);
 	}

--- a/src/transformer/utils/index.ts
+++ b/src/transformer/utils/index.ts
@@ -1,5 +1,5 @@
+import type { ZodTypeAny } from '@/internal/zod';
 import { ZodLazy } from '@/internal/zod';
-import type { ZodTypeAny } from 'zod';
 import type { ZodConstructorOrSchema } from '../generator';
 import { isZodConstructor } from '../generator';
 import type { Runner } from '../runner';
@@ -17,7 +17,7 @@ export class Utils {
 	resolveValue<
 		TInitial,
 		TFallback extends NonNullable<TInitial>,
-		TConflict extends NonNullable<TInitial>
+		TConflict extends NonNullable<TInitial>,
 	>(
 		config:
 			| {
@@ -32,7 +32,7 @@ export class Utils {
 						fallback: TFallback;
 						conflict: TConflict;
 					}) => NonNullable<TInitial>;
-			  }
+			  },
 	): NonNullable<TInitial> {
 		const { initial, fallback } = config;
 
@@ -49,7 +49,7 @@ export class Utils {
 
 	n<T>(
 		factory: (index: number) => T,
-		config: number | { min: number; max: number } = this.runner.defaults.array
+		config: number | { min: number; max: number } = this.runner.defaults.array,
 	): Array<T> {
 		const length =
 			typeof config === 'number' ? config : this.random.int(config);
@@ -59,7 +59,7 @@ export class Utils {
 
 	ifNotNever<TSchema extends ZodTypeAny>(
 		schema: TSchema | null | undefined,
-		action: (schema: TSchema) => unknown
+		action: (schema: TSchema) => unknown,
 	) {
 		if (!schema || schema._def.typeName === 'ZodNever') return;
 		action(schema);
@@ -67,7 +67,7 @@ export class Utils {
 
 	recursionCheck<TSchema extends ZodTypeAny>(
 		schema: TSchema,
-		action: (schema: TSchema) => unknown
+		action: (schema: TSchema) => unknown,
 	) {
 		if (this.isType(ZodLazy, schema)) {
 			const count = this.recursion.get(schema._def.getter) ?? 0;
@@ -79,7 +79,7 @@ export class Utils {
 
 	isType<TSchema extends ZodTypeAny>(
 		target: ZodConstructorOrSchema<TSchema>,
-		schema: ZodTypeAny
+		schema: ZodTypeAny,
 	): schema is TSchema {
 		return isZodConstructor(target)
 			? schema._def.typeName === target.name


### PR DESCRIPTION
This removes the last bits of `zod` that get pulled into our build, reducing the final size by more than half (18kb -> 7kb).