### PR TITLE
Support for BigInt Error Logging

### DIFF
--- a/.vitest/extend.ts
+++ b/.vitest/extend.ts
@@ -14,7 +14,15 @@ expect.extend({
 
 				return {
 					pass,
-					message: () => JSON.stringify({ fixture, seed, error }, null, 2),
+					message: () =>
+						JSON.stringify(
+							{ fixture, seed, error },
+							(_key, value) =>
+								// javascript does not natively support bigints in JSON.stringify
+								// https://github.com/GoogleChromeLabs/jsbi/issues/30
+								typeof value === 'bigint' ? value.toString() : value,
+							2,
+						),
 				};
 			}
 		}


### PR DESCRIPTION
We had an error in one of our tests but it failed to log correctly because `JSON.stringify` doesn't natively support BigInt 🙄

<img width="990" alt="Screenshot 2023-08-06 at 6 03 42 AM" src="https://github.com/timdeschryver/zod-fixture/assets/880190/adae1038-10d3-4141-83ae-6a4919a40aa7">
