### PR TITLE
ZodReadonly Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,7 @@
 				"vite-plugin-dts": "^1.7.3",
 				"vitepress": "^1.0.0-beta.3",
 				"vitest": "^0.31.4",
-				"zod": "^3.21.4"
-			},
-			"peerDependencies": {
-				"zod": ">=3.0.0"
+				"zod": "^3.22.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -5191,9 +5188,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.0.tgz",
+			"integrity": "sha512-y5KZY/ssf5n7hCGDGGtcJO/EBJEm5Pa+QQvFBeyMOtnFYOSflalxIFFvdaYevPhePcmcKC4aTbFkCcXN7D0O8Q==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -8803,9 +8800,9 @@
 			}
 		},
 		"zod": {
-			"version": "3.21.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-			"integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+			"version": "3.22.0",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.0.tgz",
+			"integrity": "sha512-y5KZY/ssf5n7hCGDGGtcJO/EBJEm5Pa+QQvFBeyMOtnFYOSflalxIFFvdaYevPhePcmcKC4aTbFkCcXN7D0O8Q==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
 	],
 	"author": "Tim Deschryver",
 	"license": "MIT",
-	"peerDependencies": {
-		"zod": ">=3.0.0"
-	},
 	"dependencies": {
 		"randexp": "^0.5.3"
 	},
@@ -71,7 +68,7 @@
 		"vite-plugin-dts": "^1.7.3",
 		"vitepress": "^1.0.0-beta.3",
 		"vitest": "^0.31.4",
-		"zod": "^3.21.4"
+		"zod": "^3.22.0"
 	},
 	"imports": {
 		"@/*": "./src/*",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
 	],
 	"author": "Tim Deschryver",
 	"license": "MIT",
+	"peerDependencies": {
+		"zod": ">=3.0.0"
+	},
 	"dependencies": {
 		"randexp": "^0.5.3"
 	},

--- a/src/fixture/generators/index.ts
+++ b/src/fixture/generators/index.ts
@@ -24,6 +24,7 @@ import { NumberGenerator } from './number';
 import { ObjectGenerator, RecordGenerator } from './object';
 import { OptionalGenerator } from './optional';
 import { PromiseGenerator } from './promise';
+import { ReadonlyGenerator } from './readonly';
 import { SetGenerator } from './set';
 import {
 	Cuid2Generator,
@@ -89,6 +90,7 @@ export const DEFAULT_FIXTURE_GENERATORS = [
 	NeverGenerator,
 	StringGenerator,
 	DefaultGenerator,
+	ReadonlyGenerator,
 ];
 
 export {
@@ -122,6 +124,7 @@ export {
 	OptionalGenerator,
 	PreprocessGenerator,
 	PromiseGenerator,
+	ReadonlyGenerator,
 	RecordGenerator,
 	RefinementGenerator,
 	RegexGenerator,

--- a/src/fixture/generators/readonly/index.ts
+++ b/src/fixture/generators/readonly/index.ts
@@ -1,0 +1,10 @@
+import { ZodReadonly } from '@/internal/zod';
+import { Generator } from '@/transformer/generator';
+
+export const ReadonlyGenerator = Generator({
+	schema: ZodReadonly,
+	output: ({ transform, def }) => {
+		const result = transform.fromSchema(def.innerType);
+		return Object.freeze(result);
+	},
+});

--- a/src/fixture/generators/readonly/readonly.test.ts
+++ b/src/fixture/generators/readonly/readonly.test.ts
@@ -1,0 +1,39 @@
+import { ConstrainedTransformer } from '@/transformer/transformer';
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod';
+import { ReadonlyGenerator } from '.';
+import { ArrayGenerator } from '../array';
+import { ObjectGenerator } from '../object';
+import { StringGenerator } from '../string';
+
+describe('create readonly type', () => {
+	const transform = new ConstrainedTransformer().extend([
+		ReadonlyGenerator,
+		ArrayGenerator,
+		ObjectGenerator,
+		StringGenerator,
+	]);
+
+	test('creates a readonly array', () => {
+		const schema = z.string().array();
+		const readonly = schema.readonly();
+		const result = transform.fromSchema(readonly) as z.infer<typeof schema>;
+
+		expect(() => result.push('test')).toThrow();
+		expect(() => {
+			result[0] = 'skjdfkjd';
+		}).toThrow();
+	});
+
+	test('creates a readonly object', () => {
+		const schema = z.object({
+			test: z.string(),
+		});
+		const readonly = schema.readonly();
+		const result = transform.fromSchema(readonly) as z.infer<typeof schema>;
+
+		expect(() => {
+			result.test = 'skjdfkjd';
+		}).toThrow();
+	});
+});

--- a/src/internal/zod.ts
+++ b/src/internal/zod.ts
@@ -30,6 +30,7 @@ import type {
 	ZodOptional as TrueZodOptional,
 	ZodPipeline as TrueZodPipeline,
 	ZodPromise as TrueZodPromise,
+	ZodReadonly as TrueZodReadonly,
 	ZodRecord as TrueZodRecord,
 	ZodSet as TrueZodSet,
 	ZodString as TrueZodString,
@@ -105,6 +106,7 @@ export const ZodBranded =
 	castAs<TrueZodBranded<ZodTypeAny, PropertyKey>>('ZodBranded');
 export const ZodPipeline =
 	castAs<TrueZodPipeline<ZodTypeAny, ZodTypeAny>>('ZodPipeline');
+export const ZodReadonly = castAs<TrueZodReadonly<ZodTypeAny>>('ZodReadonly');
 
 export enum ZodParsedType {
 	function = 'function',


### PR DESCRIPTION
It looks like zod simply validates the internal type then calls `Object.freeze` on the result. Seems a bit misleading because `Object.freeze` doesn't work on maps or sets, so you only get runtime guarantees for arrays and objects.

The ZodReadonly generator simply does the same thing as Zod, though I'm not sure that's any better than just returning the inner type 🤷🏼

Closes issue https://github.com/timdeschryver/zod-fixture/issues/90.
